### PR TITLE
Add new trusted brands

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -531,6 +531,7 @@ simple solution
 SimpliSafe
 SIMPLY
 SINGLES TO GO!
+SK hynix
 Skechers
 Skil
 Skittles

--- a/brands.txt
+++ b/brands.txt
@@ -294,6 +294,7 @@ John Deere
 Jolly Rancher
 Jose Cuervo
 JOYCA & CO.
+JSAUX
 Kasa Smart
 Kershaw
 Keurig
@@ -341,6 +342,7 @@ LG
 Lian Lian
 LiCB
 Linksys
+Linsoul
 Lipton
 lisle
 Listerine


### PR DESCRIPTION
I have added 3 brands in this PR that are worthy of being on this list:

- [JSAUX](https://jsaux.com): Manufactures Steam Deck accessories, among others.
- [Linsoul](https://linsoul.com): Authorized reseller of many Chinese audio equipment manufacturers.
- [SK hynix](https://skhynix.com): Flash memory manufacturer, sells SSDs and such.