### PR TITLE
add KabelDirekt

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -674,6 +674,7 @@ Justrite
 K-Y
 K&N
 K2
+KabelDirekt
 Kamenstein
 Kärcher
 Karl Lagerfeld Paris


### PR DESCRIPTION
adds KabelDirekt brand to the brand list.
This is a minor german brand that produces quality display/usb/other cables.
https://kabeldirekt-store.de/