### PR TITLE
Updated brands.txt with Bingfu and NooElec

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -264,6 +264,7 @@ Bigelow Tea
 Bikehand
 Billabong
 Billie
+Bingfu
 BioAdvanced
 Biobizz
 BioKleen
@@ -1754,6 +1755,7 @@ NOCO
 Noctua
 Nokia
 Nomos
+NooElec
 Noosa
 Nordic Naturals
 Nordic Ware


### PR DESCRIPTION
Bingfu and NooElec both sell radio technology like walkie takies and sdrs, both have existed for a long time and are well known in the radio amateur circles. If Baofeng is on the list, there two should have  a place here too.