### PR TITLE
Add 'Zoo Med' to brands list

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -3830,6 +3830,7 @@ Ziploc
 ZippyPaws
 Zodiac
 Zojirushi
+Zoo Med
 Zoom
 ZOTA
 ZOTAC


### PR DESCRIPTION
Adding brand Zoo Med: https://zoomed.com/

As seen on Amazon: https://www.amazon.com/stores/ZooMed/page/393C4101-4564-494A-8719-57862A1AFE21

I see from past PRs that GitHub is just weird about the last line. I edited this file in the GitHub UI, not even on my own machine.