### PR TITLE
Add Delsey to the list of brands

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -877,6 +877,7 @@ Dell
 Delong Lures
 DeLonghi
 Delphi
+Delsey
 Delta
 DELTA FAUCET
 Demeyere


### PR DESCRIPTION
Delsey is a French luggage brand founded in 1946.
[learn more](https://int.delsey.com/pages/about-us)