### PR TITLE
Add 'Kijaro' to brands list

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -1799,6 +1799,7 @@ KGB
 Kibbles 'n Bits
 Kick'n Bass
 Kick’n Bass
+Kijaro
 KILMAT
 Kimberly Clark
 Kimberly-Clark


### PR DESCRIPTION
Kijaro is a recognized outdoor/camping equipment brand.