### PR TITLE
Add Nex and Atari game console brands

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -225,6 +225,7 @@ Astro Tools
 AstroAI
 Astroglide
 ASUS
+Atari
 Athlon Optics
 Atlantic Safety Products
 Atlas
@@ -2350,6 +2351,7 @@ New Pro Products
 Newair
 Newport
 NewYork Cables
+Nex
 Nexa Lotte
 Next Level Racing
 Nextmug


### PR DESCRIPTION
Add Nex and Atari as known game console brands

Atari: https://atari.com/
Nex: https://www.nexplayground.com/