### PR TITLE
Some water boiler brands

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -469,6 +469,7 @@ BÖKER PLUS
 bolle
 bollé
 Bomann
+Bomann®
 Bomber Lures
 Bona Professional
 Bonavita
@@ -708,6 +709,7 @@ CIVIVI
 Clairefontaine
 Clarks
 Clatronic
+Clatronic®
 Clatronik
 CLEARALIF
 Cleco
@@ -2892,6 +2894,7 @@ Rolf Glass
 Rolling Square
 Rolo
 ROMAN
+ROMMELSBACHER
 Ronson
 Rosco
 Roseart


### PR DESCRIPTION
Wanted to check the extension using water boilers since I bought one some time ago and noticed some issues

- Bomann, Clatronic are already in the allow list but hidden/marked in red for me. Maybe missing the "®" since that's how they appear for me in amazon.de?
- ROMMELSBACHER is a reputable German brand, was even tested by the Stiftung Warentest (https://www.test.de/Wasserkocher-im-Test-4482061-detail/320000031060!8/)