### PR TITLE
Add BETAFPV and GEPRC FPV drone brands

### DIFF
--- a/brands.txt
+++ b/brands.txt
@@ -367,6 +367,7 @@ Bernard
 Bessey
 Best Lock
 Best Pet Supplies
+BETAFPV
 Better Homes and Gardens
 BetterHomes&Gardens
 Betty Crocker
@@ -1337,6 +1338,7 @@ Genuine Fred
 Geocel
 Georgia-Pacific
 Geox
+GEPRC
 GERBER
 Gerber Gear
 German Precision Optics


### PR DESCRIPTION
Adds two FPV drone brands, alphabetized and deduped per submission guidelines.

- **BETAFPV** — Shenzhen, Guangdong, China. FPV drone/quad manufacturer with dedicated website (betafpv.com), established product lines.
- **GEPRC** — Shenzhen, Guangdong, China. FPV drone manufacturer with dedicated website (geprc.com), established product lines.

Both existed for years and have dedicated websites, meeting the rule of thumb in the submission criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)